### PR TITLE
Webpack support, fix cross-browser incompatibility, improved documentation and more general styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ See [Asynchronous JavaScript Interfaces](http://medikoo.com/asynchronous-javascr
 
 ### Usage
 
+`bespoke-notes` uses `<aside>` elements as notes.
+
+```html
+...
+<section>
+  <h2>My Slide</h2>
+  <aside>
+    <p>My Notes</p>
+  </aside>
+</section>
+...
+```
+
 ```javascript
 // If your CJS bundler supports CSS modules do:
 notes = require('bespoke-notes');

--- a/dom.js
+++ b/dom.js
@@ -4,6 +4,7 @@ var primitiveSet = require('es5-ext/object/primitive-set')
   , parse        = require('querystring2/parse')
   , stringify    = require('querystring2/stringify')
   , loadCss      = require('webmake/lib/browser/load-css')
+  , classes      = require('bespoke-classes')
 
   , ignoredContexts = primitiveSet('input', 'select', 'textarea')
   , resolveQuery, invokeResize;
@@ -35,6 +36,9 @@ module.exports = function (/*options*/) {
 
 	return function (deck) {
 		var update, current, resolvedQuery;
+
+		/* If `classes` hasn't been initialized jet, do it now */
+		if (!deck.parent.classList.contains('parent')) classes()(deck);
 
 		if (queryToken) {
 			resolvedQuery = resolveQuery(queryToken);

--- a/dom.js
+++ b/dom.js
@@ -76,7 +76,7 @@ module.exports = function (/*options*/) {
 		document.addEventListener('keydown', function (e) {
 			if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
 			if (e.which !== key) return;
-			if (ignoredContexts[e.srcElement.nodeName.toLowerCase()]) return;
+			if (ignoredContexts[e.target.nodeName.toLowerCase()]) return;
 			e.preventDefault();
 
 			update(!current);

--- a/dom.js
+++ b/dom.js
@@ -38,7 +38,7 @@ module.exports = function (/*options*/) {
 		var update, current, resolvedQuery;
 
 		/* If `classes` hasn't been initialized jet, do it now */
-		if (!deck.parent.classList.contains('parent')) classes()(deck);
+		if (!deck.parent.classList.contains('bespoke-parent')) classes()(deck);
 
 		if (queryToken) {
 			resolvedQuery = resolveQuery(queryToken);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 
-require('./style');
-module.exports = require('./dom');
+require('./style.css');
+module.exports = require('./dom.js');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "git://github.com/medikoo/bespoke-notes.git"
   },
   "dependencies": {
+    "bespoke-classes": "^1.0.0",
     "es5-ext": "^0.10.7",
     "querystring2": "1",
     "webmake": "^0.3.39"

--- a/style.css
+++ b/style.css
@@ -1,16 +1,18 @@
 /* Notes hidden */
-aside { display: none; }
+.bespoke-slide > aside {
+	box-sizing: border-box;
+	position: absolute;
+	width: 100%;
+	top: 0;
+	left: 100%;
+	padding-left: 40px;
+}
 
 /* Notes exposed */
-body.notes aside { display: block; }
-
 body.notes .bespoke-slide {
-	width: 1600px;
-	margin-left: -800px;
+	-webkit-transform: scale(.5) translateX(-50%);
+	transform: scale(.5) translateX(-50%);
 }
-body.notes .bespoke-slide > div.content, body.notes .bespoke-slide > aside {
-	width: 760px;
-}
-body.notes .bespoke-slide > aside {
-	margin-left: 40px;
-}
+
+body.notes .bespoke-slide > aside { opacity: 1; }
+

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@
 	top: 0;
 	left: 100%;
 	padding-left: 40px;
+	font-size: 2em;
 }
 
 /* Notes exposed */


### PR DESCRIPTION
## Webpack Support

`require`s now use file extensions for better Webpack support.
## Cross-browser incompatibility

Replace the non standard use of `Event.srcElement` with `Event.target`.
## Improve documentation

Adds an example of how markup of sides using this extension may look.
## Add undeclared dependency to `bespoke-classes`

`bespoke-classes` is only added if you use a theme. So the extension actually didn't work when you didn't. This adds `bespoke-classes` as a dependency and initializes it, if it hasn't been done yet.
## More general styling

In earlier versions the slides had to be a specific size. I personally like to make my slides `w:100vw; h:100vh`. This PR uses a more general approach to the problem using `transform`. This last change requires a major (or at least a minor) version bump, so sorry for putting this all in one PR.
